### PR TITLE
Networking: Add support for firecracker

### DIFF
--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -409,14 +409,19 @@ func (fc *firecracker) fcAddNetDevice(endpoint Endpoint) error {
 	span, _ := fc.trace("fcAddNetDevice")
 	defer span.Finish()
 
+	//TODO: Get the name of the tap device from the endpoint pair
+	hackedName := "tap0_kata"
+
 	cfg := ops.NewPutGuestNetworkInterfaceByIDParams()
-	ifaceID := endpoint.Name()
+	//ifaceID := endpoint.Name()
+	ifaceID := hackedName
 	ifaceCfg := &models.NetworkInterface{
 		AllowMmdsRequests: false,
 		GuestMac:          endpoint.HardwareAddr(),
-		IfaceID:           &ifaceID,
-		HostDevName:       endpoint.Name(),
-		State:             "Attached",
+		//IfaceID:           &ifaceID,
+		IfaceID:     &hackedName,
+		HostDevName: hackedName, //,endpoint.Name(),
+		State:       "Attached",
 	}
 	cfg.SetBody(ifaceCfg)
 	cfg.SetIfaceID(ifaceID)

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -410,8 +410,9 @@ func createLink(netHandle *netlink.Handle, name string, expectedLink netlink.Lin
 		newLink = &netlink.Tuntap{
 			LinkAttrs: netlink.LinkAttrs{Name: name},
 			Mode:      netlink.TUNTAP_MODE_TAP,
-			Queues:    numCPUs,
-			Flags:     netlink.TUNTAP_MULTI_QUEUE_DEFAULTS | netlink.TUNTAP_VNET_HDR,
+			Flags:     netlink.TUNTAP_VNET_HDR,
+			//Queues:    numCPUs,
+			//Flags:     netlink.TUNTAP_MULTI_QUEUE_DEFAULTS | netlink.TUNTAP_VNET_HDR,
 		}
 	case (&netlink.Macvtap{}).Type():
 		qlen := expectedLink.Attrs().TxQLen


### PR DESCRIPTION
Firecracker does not support multiqueue tap. Disable the
use of multiqueue tap for now.

https://github.com/firecracker-microvm/firecracker/issues/750

Also we need to retrieve the actual tap interface name.
Right now we hardcode what we know it will be.

Note: You can only use bridged mode or tcFilter mode with
firecracker as it cannot support macvtap yet.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>