### PR TITLE
firecracker: Dynamically retrieve the VM side interface

### DIFF
--- a/virtcontainers/fc.go
+++ b/virtcontainers/fc.go
@@ -409,19 +409,14 @@ func (fc *firecracker) fcAddNetDevice(endpoint Endpoint) error {
 	span, _ := fc.trace("fcAddNetDevice")
 	defer span.Finish()
 
-	//TODO: Get the name of the tap device from the endpoint pair
-	hackedName := "tap0_kata"
-
 	cfg := ops.NewPutGuestNetworkInterfaceByIDParams()
-	//ifaceID := endpoint.Name()
-	ifaceID := hackedName
+	ifaceID := endpoint.Name()
 	ifaceCfg := &models.NetworkInterface{
 		AllowMmdsRequests: false,
 		GuestMac:          endpoint.HardwareAddr(),
-		//IfaceID:           &ifaceID,
-		IfaceID:     &hackedName,
-		HostDevName: hackedName, //,endpoint.Name(),
-		State:       "Attached",
+		IfaceID:           &ifaceID,
+		HostDevName:       endpoint.NetworkPair().TapInterface.TAPIface.Name,
+		State:             "Attached",
 	}
 	cfg.SetBody(ifaceCfg)
 	cfg.SetIfaceID(ifaceID)


### PR DESCRIPTION
Remove the hack to hardcode the interface and dynamically
retrieve the interface. This will allow us to support multiple
networks.

```
   docker network create bluenet
   docker network create rednet
   docker create -it --net bluenet --runtime=fire --name c1 busybox sh
   docker network connect rednet c1
   docker start c1
   docker exec -it ci ip a
```

We need network hotplug support to support network connect properly post
start.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>